### PR TITLE
reason: fix save path for when GOPATH contains a list of multiple paths. 

### DIFF
--- a/reason.go
+++ b/reason.go
@@ -2,8 +2,9 @@ package main
 
 import "fmt"
 import "log"
-import "os"
 import "math/rand"
+import "os"
+import "path/filepath"
 import "time"
 
 import "github.com/mewkiz/pkg/errorsutil"
@@ -20,8 +21,21 @@ import "github.com/karlek/worc/creature"
 import "github.com/karlek/worc/terrain"
 import "github.com/nsf/termbox-go"
 
-/// Debug save path.
-var debugSavePath = os.Getenv("GOPATH") + "/src/github.com/karlek/reason/debug.save"
+// reason base directory.
+var baseDir string
+
+func init() {
+	srcDir := "/src/github.com/karlek/reason/"
+	for _, goPath := range filepath.SplitList(os.Getenv("GOPATH")) {
+		baseDir = goPath + srcDir
+		_, err := os.Stat(baseDir)
+		if err == nil {
+			return
+		}
+	}
+	err := errorsutil.ErrorfColor("unable to locate reason base directory (%q) in GOPATH (%q).", srcDir, os.Getenv("GOPATH"))
+	log.Fatalln(err)
+}
 
 const (
 	// Status messages
@@ -61,7 +75,7 @@ func reason() (err error) {
 	}
 
 	// Tries to load save from path.
-	sav, err := save.New(debugSavePath)
+	sav, err := save.New(baseDir + "debug.save")
 	if err != nil {
 		return errorsutil.ErrorfColor("%s", err)
 	}


### PR DESCRIPTION
The following error was triggered before:

main.HeroAction (reason.go:176): error: open /home/u/goget:/home/u/Desktop/go/src/github.com/karlek/reason/debug.save: no such file or directory
